### PR TITLE
Redirect /writingsystems/ to /languages/

### DIFF
--- a/crubadan_clld.conf
+++ b/crubadan_clld.conf
@@ -21,6 +21,28 @@ server {
     access_log /var/log/nginx/crubadan_clld-access.log;
     error_log /var/log/nginx/crubadan_clld-error.log;
 
+
+    # In order to get maps to display on landing pages, I had to use
+    # the built-in "languages" resource and thus landing pages have to
+    # exist on the /languages/ route.
+    #
+    # This is at odds with the permanent resource URLs submitted to
+    # OLAC, which all require the /writingsystems/ route.
+    #
+    # This "rewrite" rule redirects all requests for the OLAC URLs to
+    # valid /languages/ URLs.
+    rewrite ^/writingsystems/(..+)$ /languages/$1 redirect;
+
+    # I had to do the reverse for the index page >_>
+    #
+    # In order to get the big map to *not* display on the big index
+    # (search) page, I had to *not* use the built-in languages route.
+    # Instead, the index page is on the /writingsystems/ route.
+    #
+    # This "rewrite" rule redirects any accidental navigations to the
+    # /languages index page to the correct /writingsystems index page.
+    rewrite ^/languages/?$ /writingsystems redirect;
+    
     location / {
         proxy_set_header        Host $http_host;
         proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
To fix the OLAC links problem, I've added Nginx rules that redirect them to the correct `/languages/` link.  You can test them on [the test sever](http://crubadan.octalsrc.net/).

You won't need to restart the `clld` processes or anything, just replace `/etc/nginx/conf.d/crubadan_clld.conf` with the new one (`./crubadan_clld.conf`) and restart Nginx.  

I had to change the landing pages from `/writingsystems/` to `/languages/` in order to make use of the landing-page maps automatically configured for the built-in "languages" resource.  It seems like you should be able to enable maps for custom resources, but there was no documentation or examples on how to do so, and hacking around for a couple of hours didn't get me anywhere.

I thought that the resource links on OLAC were for the `/dist/` zip files, so this change wouldn't be a problem.  Sorry!
